### PR TITLE
Fix tag namespace in `en_us.json` & `ru_ru.json`

### DIFF
--- a/src/main/resources/assets/chalk/lang/en_us.json
+++ b/src/main/resources/assets/chalk/lang/en_us.json
@@ -34,8 +34,8 @@
   "item.chalk.orange_chalk": "Orange Chalk",
   "item.chalk.white_chalk": "White Chalk",
   
-  "tag.item.c.chalks": "Chalks",
-  "tag.item.c.glowings": "Glowings",
+  "tag.item.chalk.chalks": "Chalks",
+  "tag.item.chalk.glowings": "Glowings",
 
   "gui.chalk.tooltip.hold_for_details": "§8Hold [§7Shift§8] for Details",
 

--- a/src/main/resources/assets/chalk/lang/ru_ru.json
+++ b/src/main/resources/assets/chalk/lang/ru_ru.json
@@ -34,8 +34,8 @@
 "item.chalk.orange_chalk": "Оранжевый мел",
 "item.chalk.white_chalk": "Белый мел",
 
-"tag.item.c.chalks": "Мел",
-"tag.item.c.glowings": "Светящееся",
+"tag.item.chalk.chalks": "Мел",
+"tag.item.chalk.glowings": "Светящееся",
 
 "gui.chalk.tooltip.hold_for_details": "§8Удерживайте [§7Shift§8] для подробностей.",
 


### PR DESCRIPTION
Sorry, the previous one was wrong and was from Common tags namespace.