### PR TITLE
Add compat with chalk boxes and the Create mod

### DIFF
--- a/src/main/java/io/github/mortuusars/chalk/item/component/ChalkBoxContents.java
+++ b/src/main/java/io/github/mortuusars/chalk/item/component/ChalkBoxContents.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public record ChalkBoxContents(List<ItemStack> items, int glowAmount) implements TooltipComponent {
     public static final ChalkBoxContents EMPTY = new ChalkBoxContents(NonNullList.withSize(ChalkBoxItem.SLOTS, ItemStack.EMPTY), 0);
@@ -46,6 +47,35 @@ public record ChalkBoxContents(List<ItemStack> items, int glowAmount) implements
             }
         }
 
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+
+        ChalkBoxContents that = (ChalkBoxContents) obj;
+
+        if (glowAmount != that.glowAmount()) return false;
+
+        if (items.size() != that.items.size()) return false;
+
+        for (int i = 0; i < items.size(); i++) {
+            if (!ItemStack.isSameItemSameComponents(items.get(i), that.items.get(i))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = glowAmount;
+        for (ItemStack stack : items) {
+            result = 31 * result + Objects.hashCode(ItemStack.hashItemAndComponents(stack));
+        }
+        return result;
     }
 
     public int getSelectedChalkIndex() {


### PR DESCRIPTION
Because Chalk Boxes contain items that have custom data components (chalk). This creates an issue with other mods which cannot be fixed on their side (e.g. Create, where chalk boxes can not be processed correctly through logistics components, although this may be an issue with other mods too).

Unfortunately because of the way the default `equals()`/`hashCode()` methods records work, 1.21.1 data components make issues as they compare `List<ItemStack>` using `ItemStack.equals()` instead of `ItemStack.isSameItemSameComponents()`. This is an issue when it compares two stacks that are identical but manage to have different component states.

My fix overrides `equals` and `hashCode` to use `ItemStack.isSameItemSameComponents()` and/or `ItemStack.hashItemAndComponents` with better comparison of `List<ItemStack`.